### PR TITLE
include scalaVersion in the scoinJVM subproject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val scoin = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     )
   )
   .jvmSettings(
+    scalaVersion := "2.13.8",
     crossScalaVersions := List("2.13.8", "3.1.3"),
     libraryDependencies ++= Seq(
       "fr.acinq.secp256k1" % "secp256k1-kmp-jni-jvm" % "0.6.4",


### PR DESCRIPTION
In order to successfully do `scoinJVM/publishLocal` I had to comment out all your sonatype/maven stuff in your build.sbt, so we will need to somehow fix that at some point. I left those in lines in there for now.

Here I just added a simple line that sets the scala version for the jvm project. With that line in there (and the others commented out), I was able to publish a local jvm artifact and pull it into another project. 