### PR TITLE
import error when trying to publishLocal scoinJS

### DIFF
--- a/shared/src/main/scala/UInt64.scala
+++ b/shared/src/main/scala/UInt64.scala
@@ -2,7 +2,6 @@ package scoin
 
 import scala.language.implicitConversions
 import scodec.bits.ByteVector
-import scodec.bits.HexStringSyntax
 
 case class UInt64(private val underlying: Long) extends Ordered[UInt64] {
   override def compare(o: UInt64): Int =


### PR DESCRIPTION
when doing `+scoinJS/publishLocal` I was given an error:
```
[error] 5 |import scodec.bits.HexStringSyntax
[error]   |                   ^^^^^^^^^^^^^^^
[error]   |                   value HexStringSyntax is not a member of scodec.bits
[error] one error found
[error] (scoinJS / Compile / compileIncremental) Compilation failed
```
Removing the import seemed to resolve it. Have not checked if it affects the jvm/native projects though.