### PR TITLE
Fix misc js

### DIFF
--- a/js/src/main/scala/Bindings.scala
+++ b/js/src/main/scala/Bindings.scala
@@ -6,7 +6,7 @@ import scala.scalajs.js.typedarray.Uint8Array
 import scodec.bits.ByteVector
 
 @js.native
-@JSImport("@noble-secp256k1", JSImport.Namespace)
+@JSImport("@noble/secp256k1", JSImport.Namespace)
 object Secp256k1 extends js.Object {
   def getPublicKey(
       privateKey: Uint8Array,
@@ -32,7 +32,7 @@ object Secp256k1 extends js.Object {
 }
 
 @js.native
-@JSImport("@noble-secp256k1", "CURVE")
+@JSImport("@noble/secp256k1", "CURVE")
 object Curve extends js.Object {
   def Gx: js.BigInt = js.native
   def Gy: js.BigInt = js.native
@@ -40,13 +40,13 @@ object Curve extends js.Object {
 }
 
 @js.native
-@JSImport("@noble-secp256k1", "Point")
+@JSImport("@noble/secp256k1", "Point")
 object Point extends js.Object {
   def fromHex(bytes: Uint8Array): Point = js.native
 }
 
 @js.native
-@JSImport("@noble-secp256k1", "Point")
+@JSImport("@noble/secp256k1", "Point")
 class Point(x: js.BigInt, y: js.BigInt) extends js.Object {
   def negate(): Point = js.native
   def add(point: Point): Point = js.native
@@ -57,7 +57,7 @@ class Point(x: js.BigInt, y: js.BigInt) extends js.Object {
 }
 
 @js.native
-@JSImport("@noble-secp256k1", "utils")
+@JSImport("@noble/secp256k1", "utils")
 object Secp256k1Utils extends js.Object {
   def privateNegate(privateKey: Uint8Array): Uint8Array = js.native
   def privateAdd(privateKey: Uint8Array, tweak: Uint8Array): Uint8Array =

--- a/shared/src/main/scala/Crypto.scala
+++ b/shared/src/main/scala/Crypto.scala
@@ -73,8 +73,8 @@ object Crypto extends CryptoPlatform {
     *   serialized public key, in compressed format (33 bytes)
     */
   case class PublicKey(value: ByteVector) extends PublicKeyPlatform(value) {
-    require(value.length == 33)
-    require(isPubKeyValidLax(value))
+    require(value.length == 33,s"pubkey is ${value.length} bytes but should be 33 bytes")
+    require(isPubKeyValidLax(value),"pubkey is not valid")
 
     def hash160: ByteVector = Crypto.hash160(value)
 

--- a/shared/src/main/scala/Protocol.scala
+++ b/shared/src/main/scala/Protocol.scala
@@ -210,13 +210,13 @@ object Protocol {
     writeBytes(input, out)
   }
 
-  implicit val txInSer: BtcSerializer[TxIn] = TxIn
-  implicit val txOutSer: BtcSerializer[TxOut] = TxOut
-  implicit val scriptWitnessSer: BtcSerializer[ScriptWitness] = ScriptWitness
-  implicit val txSer: BtcSerializer[Transaction] = Transaction
-  implicit val networkAddressWithTimestampSer
+  implicit def txInSer: BtcSerializer[TxIn] = TxIn
+  implicit def txOutSer: BtcSerializer[TxOut] = TxOut
+  implicit def scriptWitnessSer: BtcSerializer[ScriptWitness] = ScriptWitness
+  implicit def txSer: BtcSerializer[Transaction] = Transaction
+  implicit def networkAddressWithTimestampSer
       : BtcSerializer[NetworkAddressWithTimestamp] = NetworkAddressWithTimestamp
-  implicit val inventoryVectorOutSer: BtcSerializer[InventoryVector] =
+  implicit def inventoryVectorOutSer: BtcSerializer[InventoryVector] =
     InventoryVector
 
   def readCollection[T](


### PR DESCRIPTION
I am not sure if this "fix" here will break scoin itself or not, but it was necessary for me (I think?) in order to get my mill build here working for the js target (https://github.com/VzxPLnHqr/sig-pow/blob/add-scalajs-target/build.sc) which allows running something like `mill -i sigpow.js[3.1.3,1.10.1].runNode` and it will successfully package everything up and run it locally with `node`.

I will work on getting the same effect but properly wrapped up for the browser next. Unfortunately my little toy sigpow application is only a commandline app at the moment so I will need to rework it to operate in the browser (which I have wanted to do anyway).