### PR TITLE
Sign schnorr

### DIFF
--- a/js/src/main/scala/Bindings.scala
+++ b/js/src/main/scala/Bindings.scala
@@ -94,7 +94,7 @@ object monkeyPatch {
   }
 
   trait Sha256SyncFunctionType extends js.Function {
-    def apply(msg: Uint8Array):Uint8Array
+    def apply(msgs: Uint8Array*):Uint8Array
   }
 
   def init(): Unit = {
@@ -103,11 +103,8 @@ object monkeyPatch {
       hmacSha256Sync(key, msgs)
     }: HmacSha256SyncFunctionType)
 
-    Secp256k1.utils.asInstanceOf[js.Dynamic].sha256Sync = ({ (msg) =>
-      ByteVector.fromValidHex(
-        HashJS.sha256()
-        .update(ByteVector.view(msg).toHex,"hex")
-        .digest("hex")).toUint8Array
+    Secp256k1.utils.asInstanceOf[js.Dynamic].sha256Sync = ({ (msgs) =>
+      Crypto.sha256(ByteVector.concat(msgs.map(ByteVector.view(_)))).toUint8Array
     }: Sha256SyncFunctionType)
   }
 }

--- a/js/src/main/scala/Bindings.scala
+++ b/js/src/main/scala/Bindings.scala
@@ -61,6 +61,15 @@ object Secp256k1 extends js.Object {
     def toRawBytes(compressed: Boolean): Uint8Array = js.native
     def assertValidity(): Unit = js.native
   }
+
+  @js.native
+  object schnorr extends js.Object {
+    def signSync(msg: Uint8Array, privateKey: Uint8Array, auxRandom: Uint8Array = null): Uint8Array
+      = js.native
+
+    def verifySync(sig: Uint8Array, msg: Uint8Array, pub: Uint8Array): Boolean
+      = js.native
+  }
 }
 
 object monkeyPatch {
@@ -84,10 +93,22 @@ object monkeyPatch {
       .toUint8Array
   }
 
+  trait Sha256SyncFunctionType extends js.Function {
+    def apply(msg: Uint8Array):Uint8Array
+  }
+
   def init(): Unit = {
+
     Secp256k1.utils.asInstanceOf[js.Dynamic].hmacSha256Sync = ({ (key, msgs) =>
       hmacSha256Sync(key, msgs)
     }: HmacSha256SyncFunctionType)
+
+    Secp256k1.utils.asInstanceOf[js.Dynamic].sha256Sync = ({ (msg) =>
+      ByteVector.fromValidHex(
+        HashJS.sha256()
+        .update(ByteVector.view(msg).toHex,"hex")
+        .digest("hex")).toUint8Array
+    }: Sha256SyncFunctionType)
   }
 }
 

--- a/js/src/main/scala/CryptoPlatform.scala
+++ b/js/src/main/scala/CryptoPlatform.scala
@@ -192,6 +192,22 @@ private[scoin] trait CryptoPlatform {
       )
     )
 
+  def signSchnorrImpl(data: ByteVector32, privateKey: PrivateKey, auxrand32: Option[ByteVector32]): ByteVector64 = {
+    ByteVector64(
+      ByteVector.view(
+        Secp256k1.schnorr.signSync(
+          data.toUint8Array,
+          privateKey.value.bytes.toUint8Array,
+          auxrand32.map(_.toUint8Array).getOrElse(null)
+        )
+      )
+    )
+  }
+
+  def verifySignatureSchnorrImpl(data: ByteVector32, signature: ByteVector, publicKey: XonlyPublicKey): Boolean = {
+    Secp256k1.schnorr.verifySync(signature.toUint8Array,data.toUint8Array,publicKey.value.toUint8Array)
+  }
+
   /** Recover public keys from a signature and the message that was signed. This
     * method will return 2 public keys, and the signature can be verified with
     * both, but only one of them matches that private key that was used to

--- a/jvm/src/main/scala/CryptoPlatform.scala
+++ b/jvm/src/main/scala/CryptoPlatform.scala
@@ -190,10 +190,29 @@ private[scoin] trait CryptoPlatform {
       publicKey.value.toArray
     )
 
+  /**
+    * This is the platform specific (jvm) signining function
+    * called by Crypto.sign(..)
+    *
+    * @param data
+    * @param privateKey
+    * @return
+    */
   def sign(data: Array[Byte], privateKey: PrivateKey): ByteVector64 =
     ByteVector64(
       ByteVector.view(nativeSecp256k1.sign(data, privateKey.value.toArray))
     )
+
+  def signSchnorrImpl(data: ByteVector32, privateKey: PrivateKey, auxrand32: Option[ByteVector32]): ByteVector64 = {
+    ByteVector64(
+      ByteVector.view(nativeSecp256k1.signSchnorr(data.toArray,privateKey.value.toArray,auxrand32.map(_.toArray).getOrElse(Array.empty)))
+    )
+  }
+
+  def verifySignatureSchnorrImpl(data: ByteVector32, signature: ByteVector, publicKey: XonlyPublicKey): Boolean = {
+    //note argument order nativeSecp256k1(sig, data, pub) which is different than ours
+    nativeSecp256k1.verifySchnorr(ByteVector64(signature).toArray,data.toArray,publicKey.value.toArray)
+  }
 
   /** Recover public keys from a signature and the message that was signed. This
     * method will return 2 public keys, and the signature can be verified with

--- a/native/src/main/scala/CryptoPlatform.scala
+++ b/native/src/main/scala/CryptoPlatform.scala
@@ -226,6 +226,14 @@ private[scoin] trait CryptoPlatform {
       )
     )
 
+  def signSchnorrImpl(data: ByteVector32, privateKey: PrivateKey, auxrand32: Option[ByteVector32]): ByteVector64 = {
+    throw new NotImplementedError("implementation missing - signSchnorr - update sn-secp256k1 library and then come back and implement this")
+  }
+
+  def verifySignatureSchnorrImpl(data: ByteVector32, signature: ByteVector, publicKey: XonlyPublicKey): Boolean = {
+    throw new NotImplementedError("implementation missing - verifySignatureSchnorr - update sn-secp256k1 library and then come back and implement this")
+  }
+
   /** Recover public keys from a signature and the message that was signed. This
     * method will return 2 public keys, and the signature can be verified with
     * both, but only one of them matches that private key that was used to

--- a/shared/src/main/scala/Crypto.scala
+++ b/shared/src/main/scala/Crypto.scala
@@ -441,4 +441,38 @@ object Crypto extends CryptoPlatform {
     */
   def sign(data: ByteVector, privateKey: PrivateKey): ByteVector64 =
     sign(data.toArray, privateKey)
+
+  /**
+    * BIP340 / Schnorr
+    * https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
+    */
+  
+  trait XonlyPublicKey {
+    def toHex: String = ???
+    override def toString = s"XonlyPublicKey($toHex)"
+  }
+  object XonlyPublicKey {
+    def apply(pubKey: PublicKey): XonlyPublicKey = ???
+  }
+
+  /**
+    * Sign according to BIP340 specification 
+    * https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
+    *
+    * @param data data to sign (32 bytes)
+    * @param privateKey private key
+    * @param auxrand32
+    * @return
+    */
+  def signSchnorr(data: ByteVector32, privateKey: PrivateKey, auxrand32: Option[ByteVector32]): ByteVector64 = ???
+
+  /**
+    * Verify a BIP340 schnorr signature
+    *
+    * @param data
+    * @param signature
+    * @param publicKey
+    * @return
+    */
+  def verifySignatureSchnorr(data: ByteVector32, signature: ByteVector, publicKey: XonlyPublicKey): Boolean = ???
 }

--- a/shared/src/main/scala/Crypto.scala
+++ b/shared/src/main/scala/Crypto.scala
@@ -448,11 +448,15 @@ object Crypto extends CryptoPlatform {
     */
   
   trait XonlyPublicKey {
-    def toHex: String = ???
+    val value: ByteVector32
+    def toHex: String = value.toHex
     override def toString = s"XonlyPublicKey($toHex)"
   }
   object XonlyPublicKey {
-    def apply(pubKey: PublicKey): XonlyPublicKey = ???
+    def apply(pubKey: PublicKey): XonlyPublicKey = new XonlyPublicKey {
+      val value = ByteVector32(ByteVector.view(pubKey.value.drop(1).toArray))
+    }
+
   }
 
   /**
@@ -464,7 +468,8 @@ object Crypto extends CryptoPlatform {
     * @param auxrand32
     * @return
     */
-  def signSchnorr(data: ByteVector32, privateKey: PrivateKey, auxrand32: Option[ByteVector32]): ByteVector64 = ???
+  def signSchnorr(data: ByteVector32, privateKey: PrivateKey, auxrand32: Option[ByteVector32]): ByteVector64 =
+    signSchnorrImpl(data,privateKey,auxrand32)
 
   /**
     * Verify a BIP340 schnorr signature
@@ -474,5 +479,6 @@ object Crypto extends CryptoPlatform {
     * @param publicKey
     * @return
     */
-  def verifySignatureSchnorr(data: ByteVector32, signature: ByteVector, publicKey: XonlyPublicKey): Boolean = ???
+  def verifySignatureSchnorr(data: ByteVector32, signature: ByteVector, publicKey: XonlyPublicKey): Boolean = 
+    verifySignatureSchnorrImpl(data,signature,publicKey)
 }

--- a/shared/src/test/scala/CryptoTest.scala
+++ b/shared/src/test/scala/CryptoTest.scala
@@ -156,6 +156,7 @@ object CryptoTest extends TestSuite {
       val msg = ByteVector32.fromValidHex("0000000000000000000000000000000000000000000000000000000000000000")
       val auxrand32 = ByteVector32.fromValidHex("0000000000000000000000000000000000000000000000000000000000000000")
       val sig = Crypto.signSchnorr(msg,seckey,Some(auxrand32))
+      println(s"sig is ${sig.length} bytes: ${sig.toHex}")
       assert("E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0" == sig.toHex.toUpperCase())
       val pubkey = XonlyPublicKey(seckey.publicKey)
       assert("F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9" == pubkey.toHex.toUpperCase())

--- a/shared/src/test/scala/CryptoTest.scala
+++ b/shared/src/test/scala/CryptoTest.scala
@@ -146,5 +146,20 @@ object CryptoTest extends TestSuite {
         assert(sig == s)
       }
     }
+
+    /**
+     * Schnorr Tests
+     * inspiration taken from https://github.com/ACINQ/secp256k1-kmp/blob/master/tests/src/commonTest/kotlin/fr/acinq/secp256k1/Secp256k1Test.kt#L291
+     * */
+    test("schnorr - first schnorr signature test") {
+      val seckey = PrivateKey.fromBin(ByteVector.fromValidHex("0000000000000000000000000000000000000000000000000000000000000003"))._1
+      val msg = ByteVector32.fromValidHex("0000000000000000000000000000000000000000000000000000000000000000")
+      val auxrand32 = ByteVector32.fromValidHex("0000000000000000000000000000000000000000000000000000000000000000")
+      val sig = Crypto.signSchnorr(msg,seckey,Some(auxrand32))
+      assert("E907831F80848D1069A5371B402410364BDF1C5F8307B0084C55F1CE2DCA821525F66A4A85EA8B71E482A74F382D2CE5EBEEE8FDB2172F477DF4900D310536C0" == sig.toHex.toUpperCase())
+      val pubkey = XonlyPublicKey(seckey.publicKey)
+      assert("F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9" == pubkey.toHex.toUpperCase())
+      assert(Crypto.verifySignatureSchnorr(msg,sig,pubkey))
+    }
   }
 }


### PR DESCRIPTION
Some basic schnorr signing/verifying to make progress on #7. Currently only works with jvm. I will add more commits with implementations for scala-native and scalajs.