### PR TITLE
towards a platform-independent artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ ThisBuild / tlSonatypeUseLegacyHost := false
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-lazy val root = tlCrossRootProject.aggregate(scoin, scoinReckless)
+lazy val root = tlCrossRootProject.aggregate(scoin)
 
 // libraries used across all platforms (jvm, js, native)
 lazy val commonLibraryDependencies = Def.setting{

--- a/reckless/shared/src/main/scala/CryptoPlatform.scala
+++ b/reckless/shared/src/main/scala/CryptoPlatform.scala
@@ -1,0 +1,14 @@
+package scoin
+import scodec.bits._
+import scoin._
+
+private[scoin] trait CryptoPlatform extends reckless.CryptoPlatformImpl {
+  /**
+    * This trait only exists here as a stub so that it has the correct
+    * name (CryptoPlatform) which is the name of the trait which the `Crypto`
+    * object extends.
+    * 
+    * All platform-independent implementations are provided in
+    * `reckless.CryptoPlatformImpl`
+    */
+}

--- a/reckless/shared/src/test/scala/RecklessTest.scala
+++ b/reckless/shared/src/test/scala/RecklessTest.scala
@@ -1,0 +1,17 @@
+package scoin
+
+import utest._
+
+import scodec.bits._
+
+object RecklessTest extends TestSuite {
+    val tests = Tests {
+        test("reckless hello"){
+            assert(true)
+        }
+        
+        test("reckless sha256"){
+            scoin.Crypto.sha256(ByteVector("abcd".getBytes))
+        }
+    }
+}

--- a/shared/src/main/scala/reckless/CryptoPlatformImpl.scala
+++ b/shared/src/main/scala/reckless/CryptoPlatformImpl.scala
@@ -1,0 +1,282 @@
+package scoin.reckless
+
+import scoin._
+import scodec.bits._ 
+
+private[scoin] trait CryptoPlatformImpl {
+  import Crypto._
+  /**
+    * NOTE: The below commented-out implementations were taken from the
+    * jvm-specific `CryptoPlatform`. As the goal here is to re-implement everything
+    * in a platform-independent fashion, the implementations have been commented
+    * out and replaced with `???`.
+    * 
+    * This note will be removed after the platform-independent implementations are
+    * completed.
+    */
+
+  //private val secureRandom = new SecureRandom
+  def randomBytes(length: Int): ByteVector = ??? /*{
+    val buffer = new Array[Byte](length)
+    secureRandom.nextBytes(buffer)
+    ByteVector.view(buffer)
+  }*/
+
+  def G: PublicKey = ??? // PublicKey(ByteVector.view(curve.getG().getEncoded(true)))
+  def N: java.math.BigInteger = ??? // curve.getN
+
+  /*private val params = SECNamedCurves.getByName("secp256k1")
+  private val curve = new ECDomainParameters(
+    params.getCurve,
+    params.getG,
+    params.getN,
+    params.getH
+  )
+
+  private val zero = BigInteger.valueOf(0)
+  private val one = BigInteger.valueOf(1)
+  private lazy val nativeSecp256k1: Secp256k1 = Secp256k1.get()
+  */
+
+  private[scoin] class PrivateKeyPlatform(value: ByteVector32) {
+    def add(that: PrivateKey): PrivateKey = ???
+      /*PrivateKey(
+        ByteVector32(
+          ByteVector.view(
+            nativeSecp256k1.privKeyTweakAdd(value.toArray, that.value.toArray)
+          )
+        )
+      )*/
+
+    def subtract(that: PrivateKey): PrivateKey = ???
+      /*PrivateKey(
+        ByteVector32(
+          ByteVector.view(
+            nativeSecp256k1.privKeyTweakAdd(
+              value.toArray,
+              nativeSecp256k1.privKeyNegate(that.value.toArray)
+            )
+          )
+        )
+      )*/
+
+    def multiply(that: PrivateKey): PrivateKey = ???
+      /*PrivateKey(
+        ByteVector32(
+          ByteVector.view(
+            nativeSecp256k1.privKeyTweakMul(value.toArray, that.value.toArray)
+          )
+        )
+      )*/
+
+    def publicKey: PublicKey = ???
+      /*PublicKey.fromBin(
+        ByteVector.view(nativeSecp256k1.pubkeyCreate(value.toArray))
+      )*/
+  }
+
+  private[scoin] class PublicKeyPlatform(value: ByteVector) {
+    def add(that: PublicKey): PublicKey = ???
+      /*PublicKey.fromBin(
+        ByteVector.view(
+          nativeSecp256k1.pubKeyCombine(
+            Array(value.toArray, that.value.toArray)
+          )
+        )
+      )*/
+
+    def add(that: PrivateKey): PublicKey = ???
+      /*PublicKey.fromBin(
+        ByteVector.view(
+          nativeSecp256k1.privKeyTweakAdd(value.toArray, that.value.toArray)
+        )
+      )*/
+
+    def subtract(that: PublicKey): PublicKey = ???
+      /*PublicKey.fromBin(
+        ByteVector.view(
+          nativeSecp256k1.pubKeyCombine(
+            Array(
+              value.toArray,
+              nativeSecp256k1.pubKeyNegate(that.value.toArray)
+            )
+          )
+        )
+      )*/
+
+    def multiply(that: PrivateKey): PublicKey = ???
+      /*PublicKey.fromBin(
+        ByteVector.view(
+          nativeSecp256k1.pubKeyTweakMul(value.toArray, that.value.toArray)
+        )
+      )*/
+
+    def toUncompressedBin: ByteVector = ???
+      // ByteVector.view(nativeSecp256k1.pubkeyParse(value.toArray))
+  }
+
+  /*private def hash(digest: Digest)(input: ByteVector): ByteVector = {
+    ???
+    /*digest.update(input.toArray, 0, input.length.toInt)
+    val out = new Array[Byte](digest.getDigestSize)
+    digest.doFinal(out, 0)
+    ByteVector.view(out)*/
+  }*/
+
+  def sha1: ByteVector => ByteVector = ??? // hash(new SHA1Digest) _
+
+  def sha256: ByteVector => ByteVector32 = ??? // = (x: ByteVector) => ByteVector32(hash(new SHA256Digest)(x))
+
+  def sha512: ByteVector => ByteVector = ??? // = (x: ByteVector) => hash(new SHA512Digest)(x)
+
+  def hmac512(key: ByteVector, data: ByteVector): ByteVector = ??? /*{
+    val mac = new HMac(new SHA512Digest())
+    mac.init(new KeyParameter(key.toArray))
+    mac.update(data.toArray, 0, data.length.toInt)
+    val out = new Array[Byte](64)
+    mac.doFinal(out, 0)
+    ByteVector.view(out)
+  }*/
+
+  def hmac256(key: ByteVector, data: ByteVector): ByteVector32 = ??? /*{
+    val mac = new HMac(new SHA256Digest())
+    mac.init(new KeyParameter(key.toArray))
+    mac.update(data.toArray, 0, data.length.toInt)
+    val out = new Array[Byte](32)
+    mac.doFinal(out, 0)
+    ByteVector32(ByteVector.view(out))
+  }*/
+
+  def ripemd160: ByteVector => ByteVector = ??? // = hash(new RIPEMD160Digest) _
+
+  /** @param key
+    *   serialized public key
+    * @return
+    *   true if the key is valid. This check is much more expensive than its lax
+    *   version since here we check that the public key is a valid point on the
+    *   secp256k1 curve
+    */
+  def isPubKeyValidStrict(key: ByteVector): Boolean = ??? /*
+    isPubKeyValidLax(key) &&
+      nativeSecp256k1.pubkeyParse(key.toArray).length == 65*/
+
+  def compact2der(signature: ByteVector64): ByteVector = ??? /*{
+    val r = new BigInteger(1, signature.take(32).toArray)
+    val s = new BigInteger(1, signature.takeRight(32).toArray)
+    val (r1, s1) = normalizeSignature(r, s)
+    val bos = new ByteArrayOutputStream(73)
+    val seq = new DERSequenceGenerator(bos)
+    seq.addObject(new ASN1Integer(r1))
+    seq.addObject(new ASN1Integer(s1))
+    seq.close()
+    ByteVector.view(bos.toByteArray)
+  }*/
+
+  def verifySignature(
+      data: Array[Byte],
+      signature: Array[Byte],
+      publicKey: PublicKey
+  ): Boolean = ??? /*
+    nativeSecp256k1.verify(
+      signature,
+      data,
+      publicKey.value.toArray
+    )*/
+
+  /** This is the platform specific (jvm) signining function called by
+    * Crypto.sign(..)
+    *
+    * @param data
+    * @param privateKey
+    * @return
+    */
+  def sign(data: Array[Byte], privateKey: PrivateKey): ByteVector64 = ???
+    /*ByteVector64(
+      ByteVector.view(nativeSecp256k1.sign(data, privateKey.value.toArray))
+    )*/
+
+  def signSchnorrImpl(
+      data: ByteVector32,
+      privateKey: PrivateKey,
+      auxrand32: Option[ByteVector32]
+  ): ByteVector64 = ??? /*{
+    ByteVector64(
+      ByteVector.view(
+        nativeSecp256k1.signSchnorr(
+          data.toArray,
+          privateKey.value.toArray,
+          auxrand32.map(_.toArray).getOrElse(Array.empty)
+        )
+      )
+    )
+  }*/
+
+  def verifySignatureSchnorrImpl(
+      data: ByteVector32,
+      signature: ByteVector64,
+      publicKey: XOnlyPublicKey
+  ): Boolean = ??? /*{
+    // note argument order nativeSecp256k1(sig, data, pub) which is different than ours
+    nativeSecp256k1.verifySchnorr(
+      signature.toArray,
+      data.toArray,
+      publicKey.value.toArray
+    )
+  }*/
+
+  /** Recover public keys from a signature and the message that was signed. This
+    * method will return 2 public keys, and the signature can be verified with
+    * both, but only one of them matches that private key that was used to
+    * generate the signature.
+    *
+    * @param signature
+    *   signature
+    * @param message
+    *   message that was signed
+    * @return
+    *   a recovered public key
+    */
+  def recoverPublicKey(
+      signature: ByteVector64,
+      message: ByteVector,
+      recoveryId: Int
+  ): PublicKey = ??? /*{
+    val bin = nativeSecp256k1.ecdsaRecover(
+      signature.toArray,
+      message.toArray,
+      recoveryId
+    )
+    PublicKey.fromBin(ByteVector.view(bin))
+  }*/
+
+  def chacha20(
+      input: ByteVector,
+      key: ByteVector,
+      nonce: ByteVector
+  ): ByteVector = ??? // ChaCha20.xor(input, key, nonce)
+
+  object ChaCha20Poly1305 {
+    def encrypt(
+        plaintext: ByteVector,
+        key: ByteVector,
+        nonce: ByteVector,
+        aad: ByteVector
+    ): ByteVector = ??? /*{
+      val (payload, mac) = c20p1305encrypt(plaintext, key, nonce, aad)
+      payload ++ mac
+    }*/
+
+    def decrypt(
+        ciphertext: ByteVector,
+        key: ByteVector,
+        nonce: ByteVector,
+        aad: ByteVector
+    ): ByteVector = ??? /*c20p1305decrypt(
+      ciphertext.dropRight(16),
+      key,
+      nonce,
+      aad,
+      ciphertext.takeRight(16)
+    )*/
+  }
+}


### PR DESCRIPTION
I started the process of creating `scoinReckless` which will have platform-independent, yet inefficient and somewhat reckless implementations of the things.

One reason for doing this is that it will allow us to easily create little scripts and whatnot which will not need to pre-suppose any javascript, jvm, or native dependencies. So cooking up examples or simple little `scoin` utilities using tools like `scala-cli` should be much easier.

All these platform-independent implementations can live in the parent `scoin.reckless` package (inside the `scoin` sbt project itself), and the sbt cross-project `scoinReckless` is therefore simply a "stub." This seems to be the cleanest solution for now until when/if we do a massive refactor.

So, all that to say, in order for `scoinReckless` to be useful, we need to publish it as a different artifact. I do not know how the maven magic line in the `build.sbt` file works which does the publishing of the artifacts, so I left that part out for now. 

Right now somebody can pull in `scoin` into their project by doing something like:
`//> using lib "com.fiatjaf::scoin:0.5.0"` (for scala-cli / mill) or `libraryDependencies += "com.fiatjaf" %%% "scoin" % "0.5.0"` (for sbt projects).

I think the goal should be to publish it so that all they need to do is change `"scoin"` to `"scoin-reckless"` and things just work.

