### PR TITLE
fix pay2wpkh, and include new test

### DIFF
--- a/shared/src/main/scala/Script.scala
+++ b/shared/src/main/scala/Script.scala
@@ -1950,16 +1950,17 @@ object Script {
             witness.stack.length == 2,
             "Invalid witness program, should have 2 items"
           )
-          val finalStack = run(
-            OP_DUP :: OP_HASH160 :: OP_PUSHDATA(
+          val pay2pkhScript = OP_DUP :: OP_HASH160 :: OP_PUSHDATA(
               program
-            ) :: OP_EQUALVERIFY :: OP_CHECKSIG :: Nil,
+            ) :: OP_EQUALVERIFY :: OP_CHECKSIG :: Nil
+          val finalStack = run(
+            pay2pkhScript,
             witness.stack.reverse.toList,
             State(
               conditions = List.empty[Boolean],
               altstack = List.empty[ByteVector],
               opCount = 0,
-              scriptCode = Script.parse(program)
+              scriptCode = pay2pkhScript
             ),
             SigVersion.SIGVERSION_WITNESS_V0
           )


### PR DESCRIPTION
Turns out that when I added taproot to scoin (by mostly blindly following acinq's code and learning taproot along the way), I failed to properly handle `pay2wpkh`. That is now fixed by this PR.

I actually fixed it a few months ago for a nearly identical problem pertaining to `pay2wsh` but did not think to check the `pay2wpkh` code at that time.

Also, I ran `+root/test` in `sbt` before submitting this PR and all tests pass, despite the strange linking error of some sort for native:
```
[info] Tests: 74, Passed: 74, Failed: 0
[error] Undefined definitions found in reachability phase
[error] (scoinNative / Test / nativeLink) Undefined definitions found in reachability phase
```