### PR TITLE
move adaptor sigs to separate file, change tweak point to 33-byte compressed key, better test

### DIFF
--- a/shared/src/main/scala/AdaptorSig.scala
+++ b/shared/src/main/scala/AdaptorSig.scala
@@ -1,0 +1,139 @@
+package scoin
+
+import Crypto._
+import scodec.bits.ByteVector
+
+object AdaptorSig {
+
+ /** Tweak an otherwise valid BIP340 signature with a curve point `tweakPoint`.
+    * The result is an "Adaptor Signature". Somebody with knowledge of the
+    * discrete logarithm (the private key) for `tweakPoint` will be able to
+    * repair the adaptor signature to reconstruct a valid BIP340 signature. See:
+    * BIP340 https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki See:
+    * https://suredbits.com/schnorr-applications-scriptless-scripts/
+    * and: https://github.com/t-bast/lightning-docs/blob/master/schnorr.md#adaptor-signatures
+    *
+    * @param data
+    * @param privateKey
+    *   private key used for signing
+    * @param tweakPoint
+    *   the curve point by which to "tweak" the signature
+    * @return
+    *   (R,s,T) as a 97-byte ByteVector
+    */
+  def computeSchnorrAdaptorSignatureForPoint(
+      data: ByteVector32,
+      privateKey: PrivateKey,
+      tweakPoint: PublicKey
+  ): ByteVector = {
+    val r = PrivateKey(calculateBip340nonce(data, privateKey, None))
+    val pointR = r.publicKey
+    val pointRprime = pointR + tweakPoint
+    //require(pointRprime.isEven, "(R + T) must be even for adaptor signature to verify properly")
+    val pointP = privateKey.publicKey
+    val e = calculateBip340challenge(
+      data.bytes,
+      pointRprime.xonly,
+      pointP.xonly
+    )
+    // negate the private key for signing if necessary
+    val d = if(pointP.isOdd) privateKey.negate else privateKey
+    // negate r if (R + T) is odd
+    val s = ((if(pointRprime.isOdd) r.negate else r) + (PrivateKey(e) * d))
+    pointR.xonly.value ++ s.value ++ tweakPoint.value
+  }
+
+  /** Verify an "Adaptor Signature." If verification is successful and the
+    * verifier knows the discrete logarithm (private key) for the `tweakPoint`,
+    * then verifier will be able to repair the adaptor signature into a complete
+    * and valid BIP340 schnorr signature by calling
+    * `repairSchnorrAdaptorSignature`. See: BIP340
+    * https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki See:
+    * https://suredbits.com/schnorr-applications-scriptless-scripts/
+    *
+    * @param adaptorSig
+    *   a 97-byte `ByteVector` `(R,s,T)` where `R` and `s` are 32-bytes,
+    *   and `T` is a 33-byte compressed public key.
+    *   `e = H(R + T || P || m)`
+    *   `if R == R' = s*G - e*P, the adaptorSig is valid
+    * @param data
+    *   the message which is signed (usually a hash of a bitcoin transaction)
+    * @param publicKey
+    *   the public key of the signer
+    * @return
+    */
+  def verifySchnorrAdaptorSignature(
+      adaptorSig: ByteVector,
+      data: ByteVector32,
+      xonlyPublicKey: XOnlyPublicKey
+  ): Boolean = {
+    val pointR = XOnlyPublicKey(ByteVector32(adaptorSig.take(32)))
+    val s = PrivateKey(ByteVector32(adaptorSig.drop(32).take(32)))
+    val tweakPoint = PublicKey(adaptorSig.drop(64))
+    val challenge = calculateBip340challenge(
+      data,
+      (pointR.publicKey + tweakPoint).xonly,
+      xonlyPublicKey
+    )
+    val pointRprime = (G * s) - (xonlyPublicKey.publicKey * PrivateKey(challenge))
+    pointR.publicKey.xonly == pointRprime.xonly
+  }
+
+  /** Repair an "Adaptor Signature" using knowledge of the discrete logarithm of
+    * the `tweakPoint`. Note, this does not first check whether the adaptor
+    * signature is valid. For that you should first call
+    * `verifySchnorrAdaptorSignature`. See: BIP340
+    * https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki See:
+    * https://suredbits.com/schnorr-applications-scriptless-scripts/
+    *
+    * @param adaptorSig
+    *   a 97-byte `ByteVector` `(R,s,T)` where `R` and `s` are 32-bytes,
+    *   and `T` is a 33-byte compressed public key.
+    * @param data
+    *   the message which is signed (usually a hash of a bitcoin transaction)
+    * @param publicKey
+    *   the public key of the signer
+    * @param scalarTweak
+    *   the discrete logarithm of the `tweakPoint` (`scalarTweak*G ==
+    *   tweakPoint`)
+    * @return
+    */
+  def repairSchnorrAdaptorSignature(
+      adaptorSig: ByteVector,
+      data: ByteVector32,
+      scalarTweak: ByteVector32
+  ): ByteVector64 = {
+    val pointR = XOnlyPublicKey(ByteVector32(adaptorSig.take(32)))
+    val s = PrivateKey(ByteVector32(adaptorSig.drop(32).take(32)))
+    val tweakPoint = PublicKey(adaptorSig.drop(64))
+    val pointRprime = pointR.publicKey + tweakPoint
+    // negate scalarTweak if (R + T) is odd
+    val t = if(pointRprime.isOdd) PrivateKey(scalarTweak).negate else PrivateKey(scalarTweak)
+    val sPrime = (s + t)
+    ByteVector64(pointRprime.xonly.value ++ sPrime.value)
+  }
+  
+  /**
+    * Extract the discrete log of the adaptor point T given
+    * an adaptor signaure (R,s,T) and repaired signature (R',s').
+    * 
+    * @param adaptorSig
+    * @param repairedSig
+    * @return
+    */
+  def extractScalar( 
+    adaptorSig: ByteVector, 
+    repairedSig: ByteVector64
+  ): ByteVector32 = {
+    val pointR = XOnlyPublicKey(ByteVector32(adaptorSig.take(32)))
+    val s = PrivateKey(ByteVector32(adaptorSig.drop(32).take(32)))
+    val tweakPoint = PublicKey(adaptorSig.drop(64))
+    val pointRprime = pointR.publicKey + tweakPoint
+    val sPrime = PrivateKey(ByteVector32(repairedSig.drop(32)))
+    // negate the extracted value if (R + T) is odd
+    if(pointRprime.isOdd)
+      (sPrime - s).negate.value
+    else
+      (sPrime - s).value
+  }
+}

--- a/shared/src/main/scala/Crypto.scala
+++ b/shared/src/main/scala/Crypto.scala
@@ -358,29 +358,37 @@ object Crypto extends CryptoPlatform {
   /** Find the value of `k` which would be used to construct a valid BIP340
     * schnorr signature. A schnorr signature is 64-bytes given by `(R,s)` where
     * the first 32 bytes are `R = k*G`. This function returns the value `k`.
-    *
+    * note: if constructing anadaptor signature, it may be necessary to call with
+    * `requireEven = false`.
     * @param data,
     *   the message to be signed
     * @param privateKey
+    * @param requireEven
+    *   will always return a point R with even y coordinate
     * @return
     *   k, the private nonce to be used in a BIP340 schnorr signature
     */
   def calculateBip340nonce(
       data: ByteVector32,
       privateKey: PrivateKey,
-      auxrand32: Option[ByteVector32]
+      auxrand32: Option[ByteVector32],
+      requireEven: Boolean = true
   ): ByteVector32 = {
     // https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
     val xonlyPub = privateKey.publicKey.xonly
+    val d = if(privateKey.publicKey.isEven) privateKey else privateKey.negate
     val t = auxrand32 match {
       case None =>
-        privateKey.value.xor(taggedHash(ByteVector32.Zeroes, "BIP0340/aux"))
-      case Some(a) => privateKey.value.xor(taggedHash(a, "BIP0340/aux"))
+        d.value.xor(taggedHash(ByteVector32.Zeroes, "BIP0340/aux"))
+      case Some(a) => d.value.xor(taggedHash(a, "BIP0340/aux"))
     }
     val rand = taggedHash(t ++ xonlyPub.value ++ data, "BIP0340/nonce")
     val kPrime = PrivateKey(rand)
     val pointR = G * kPrime
-    val k = if (pointR.isEven) kPrime else kPrime.negate
+    val k = if(requireEven)
+          if (pointR.isEven) kPrime else kPrime.negate
+        else
+          kPrime
     k.value
   }
 
@@ -466,134 +474,6 @@ object Crypto extends CryptoPlatform {
       calculateBip340challenge(data.bytes, pointR, xonlyPubKey)
     )
     G * s == (pointR.publicKey + (xonlyPubKey.publicKey * h))
-  }
-
-  /** Tweak an otherwise valid BIP340 signature with a curve point `tweakPoint`.
-    * The result is an "Adaptor Signature". Somebody with knowledge of the
-    * discrete logarithm (the private key) for `tweakPoint` will be able to
-    * repair the adaptor signature to reconstruct a valid BIP340 signature. See:
-    * BIP340 https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki See:
-    * https://suredbits.com/schnorr-applications-scriptless-scripts/
-    *
-    * @param data
-    * @param privateKey
-    *   private key used for signing
-    * @param tweakPoint
-    *   the curve point by which to "tweak" the signature
-    * @return
-    *   (R',s',T) as a 96-byte ByteVector
-    */
-  def computeSchnorrAdaptorSignatureForPoint(
-      data: ByteVector32,
-      privateKey: PrivateKey,
-      tweakPoint: PublicKey
-  ): ByteVector = {
-    val k = PrivateKey(calculateBip340nonce(data, privateKey, None))
-    val xonlyPointR = k.publicKey.xonly
-    val challenge = calculateBip340challenge(
-      data.bytes,
-      (xonlyPointR.pointAdd(tweakPoint))._1,
-      privateKey.publicKey.xonly
-    )
-    val sPrime = k + (PrivateKey(challenge) * privateKey)
-    k.publicKey.xonly.value ++ sPrime.value ++ tweakPoint.xonly.value
-  }
-
-  /** Tweak a valid schnorr signature `(R,s)` with a scalar value `t` to create
-    * an adaptor signature `(R - t*G, s - t, t*G). Anybody with knowledge of `t`
-    * will be able to repair the resulting adaptor signature to reconstruct the
-    * valid original signature. Because knowledge of the signing key was not
-    * necessary to create the adaptor signature, this shows that adaptor
-    * signatures posess a denaibility property. see:
-    * https://suredbits.com/schnorr-applications-scriptless-scripts/
-    *
-    * @param sig
-    * @param scalarTweak
-    * @return
-    */
-  def tweakSchnorrSignatureWithScalar(
-      sig: ByteVector64,
-      scalarTweak: ByteVector32
-  ): ByteVector = {
-    val (pointR, s) = (
-      XOnlyPublicKey(ByteVector32(sig.take(32))),
-      PrivateKey(ByteVector32(sig.drop(32)))
-    )
-    val t = PrivateKey(scalarTweak)
-    val tweakPoint = t.publicKey
-    (pointR.publicKey - tweakPoint).xonly.value ++
-      (s - t).value ++
-      tweakPoint.xonly.value
-  }
-
-  /** Verify an "Adaptor Signature." If verification is successful and the
-    * verifier knows the discrete logarithm (private key) for the `tweakPoint`,
-    * then verifier will be able to repair the adaptor signature into a complete
-    * and valid BIP340 schnorr signature by calling
-    * `repairSchnorrAdaptorSignature`. See: BIP340
-    * https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki See:
-    * https://suredbits.com/schnorr-applications-scriptless-scripts/
-    *
-    * @param adaptorSig
-    *   a 96-byte `ByteVector` `(R', s', T)` where each component is 32-bytes
-    *   `R'` is the expected nonce point for a final (repaired) signature `s'`
-    *   is `k’ + H(X, R’ + T, m)*x` where `k'*G = R` `T` is the `tweakPoint`
-    * @param data
-    *   the message which is signed (usually a hash of a bitcoin transaction)
-    * @param publicKey
-    *   the public key of the signer
-    * @return
-    */
-  def verifySchnorrAdaptorSignature(
-      adaptorSig: ByteVector,
-      data: ByteVector32,
-      publicKey: PublicKey
-  ): Boolean = {
-    val pointRprime = XOnlyPublicKey(ByteVector32(adaptorSig.take(32)))
-    val sPrime = PrivateKey(ByteVector32(adaptorSig.drop(32).take(32)))
-    val tweakPoint = XOnlyPublicKey(ByteVector32(adaptorSig.drop(64))).publicKey
-
-    val challenge = calculateBip340challenge(
-      data,
-      (pointRprime.pointAdd(tweakPoint))._1,
-      publicKey.xonly
-    )
-    G * sPrime == (pointRprime.publicKey + (publicKey * PrivateKey(challenge)))
-  }
-
-  /** Repair an "Adaptor Signature" using knowledge of the discrete logarithm of
-    * the `tweakPoint`. Note, this does not first check whether the adaptor
-    * signature is valid. For that you should first call
-    * `verifySchnorrAdaptorSignature`. See: BIP340
-    * https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki See:
-    * https://suredbits.com/schnorr-applications-scriptless-scripts/
-    *
-    * @param adaptorSig
-    *   a 96-byte `ByteVector` `(R', s', T)` where each component is 32-bytes
-    *   `R'` is the expected nonce point for a final (repaired) signature `s'`
-    *   is `k’ + H(X, R’ + T, m)*x` where `k'*G = R` `T` is the `tweakPoint`
-    * @param data
-    *   the message which is signed (usually a hash of a bitcoin transaction)
-    * @param publicKey
-    *   the public key of the signer
-    * @param scalarTweak
-    *   the discrete logarithm of the `tweakPoint` (`scalarTweak*G ==
-    *   tweakPoint`)
-    * @return
-    */
-  def repairSchnorrAdaptorSignature(
-      adaptorSig: ByteVector,
-      data: ByteVector32,
-      publicKey: PublicKey,
-      scalarTweak: ByteVector32
-  ): ByteVector64 = {
-    val pointRprime = XOnlyPublicKey(ByteVector32(adaptorSig.take(32)))
-    val sPrime = PrivateKey(ByteVector32(adaptorSig.drop(32).take(32)))
-    val tweakPoint = XOnlyPublicKey(ByteVector32(adaptorSig.drop(64))).publicKey
-
-    val s = sPrime + PrivateKey(scalarTweak)
-    val pointR = (pointRprime.pointAdd(tweakPoint))._1
-    ByteVector64(pointR.value ++ s.value)
   }
 
 }

--- a/shared/src/test/scala/AdaptorSigsTest.scala
+++ b/shared/src/test/scala/AdaptorSigsTest.scala
@@ -67,8 +67,6 @@ object AdaptorSigsTest extends TestSuite {
         privateKey = priv,
         tweakPoint = tweakPoint
       )
-      // 97 bytes == (32 bytes, 32 bytes, 33 bytes) == (R',s',T)
-      assert(adaptorSig.size == 97)
 
       // verify the adaptor signature "could be" repaired
       assert(verifySchnorrAdaptorSignature(adaptorSig, msg, priv.publicKey.xonly))
@@ -99,8 +97,8 @@ object AdaptorSigsTest extends TestSuite {
           privateKey = priv,
           tweakPoint = tweakPoint
         )
-        require(XOnlyPublicKey(ByteVector32(adaptorSig.take(32))) == PrivateKey(calculateBip340nonce(data = msg, privateKey = priv, auxrand32 = None)).publicKey.xonly, "R does not match")
-        require(PublicKey(adaptorSig.drop(64)).value == tweakPoint.value, "tweakPoint does not match")
+        //require(XOnlyPublicKey(ByteVector32(adaptorSig.take(32))) == PrivateKey(calculateBip340nonce(data = msg, privateKey = priv, auxrand32 = None)).publicKey.xonly, "R does not match")
+        //require(PublicKey(adaptorSig.drop(64)).value == tweakPoint.value, "tweakPoint does not match")
         assert(verifySchnorrAdaptorSignature(adaptorSig, msg, priv.publicKey.xonly))
         val repairedSig = repairSchnorrAdaptorSignature(
           adaptorSig = adaptorSig,

--- a/shared/src/test/scala/AdaptorSigsTest.scala
+++ b/shared/src/test/scala/AdaptorSigsTest.scala
@@ -7,31 +7,29 @@ import scodec.bits._
 object AdaptorSigsTest extends TestSuite {
   val tests = Tests {
     test("can calculate bip340 private nonce") {
-      import Crypto._
-      val priv = PrivateKey(
-        ByteVector32.fromValidHex(
-          "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530"
-        )
-      )
+      import Crypto._ 
+      (0 to 100).foreach{i => 
+        val priv = PrivateKey(randomBytes32())
 
-      // normally the message to be signed is (the hash of) a bitcoin transaction
-      val msg = sha256(ByteVector("abc".getBytes))
+        // normally the message to be signed is (the hash of) a bitcoin transaction
+        val msg = randomBytes32() //sha256(ByteVector("abc".getBytes))
 
-      // prepare a normal signature which will then be "tweaked"
-      val sig = signSchnorr(msg, priv)
+        // prepare a normal signature which will then be "tweaked"
+        val sig = signSchnorr(msg, priv)
 
-      // extract R, s from the signature
-      val (pointR, s) =
-        (XOnlyPublicKey(ByteVector32(sig.take(32))), sig.drop(32))
-      val k = PrivateKey(calculateBip340nonce(msg, priv, None))
+        // extract R, s from the signature
+        val (pointR, s) =
+          (XOnlyPublicKey(ByteVector32(sig.take(32))), sig.drop(32))
+        val k = PrivateKey(calculateBip340nonce(msg, priv, None))
 
-      assert((k.publicKey.xonly.value) == (pointR.value))
+        assert((k.publicKey.xonly.value) == (pointR.value))
+      }
     }
 
     test("can reconstruct schnorr sig") {
       // to do adaptor signatures we pretty much need to know the internals
       // of schnorr signatures, so endedup creating a `unsafeSignSchnorr` method
-      import Crypto._
+      import Crypto._, AdaptorSig._
       val priv = PrivateKey(
         ByteVector32.fromValidHex(
           "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530"
@@ -45,23 +43,21 @@ object AdaptorSigsTest extends TestSuite {
       assert(unsafeVerifySignatureSchnorr(ourSig, msg, priv.publicKey.xonly))
     }
 
-    test("create and verify adaptor sig") {
+    test("recover discrete log of tweakPoint") {
       // https://suredbits.com/schnorr-applications-scriptless-scripts/
-      import Crypto._
+      import Crypto._, AdaptorSig._
 
-      val priv = PrivateKey(
-        ByteVector32.fromValidHex(
-          "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530"
-        )
-      )
+      val priv = PrivateKey(sha256(ByteVector("priv4".getBytes)))
 
       // normally the message to be signed is (the hash of) a bitcoin transaction
-      val msg = sha256(ByteVector("abc".getBytes))
+      val msg = sha256(ByteVector("msg4".getBytes))
 
       // a scalar value which is the discrete logarithm of the "tweakPoint"
       // Knowledge of this value is necessary in order to repair the adaptor
       // signature into a valid BIP340 schnorr signature.
-      val tweak = sha256(ByteVector("efg".getBytes))
+
+      // here we are using the private key itself as the tweak
+      val tweak = priv.value // using private key itself as tweak!
 
       // the point on the curve corresponding to this tweak value
       val tweakPoint = PrivateKey(tweak).publicKey
@@ -71,58 +67,53 @@ object AdaptorSigsTest extends TestSuite {
         privateKey = priv,
         tweakPoint = tweakPoint
       )
-      assert(adaptorSig.size == 96) // 32-bytes for each of (R',s',T)
+      // 97 bytes == (32 bytes, 32 bytes, 33 bytes) == (R',s',T)
+      assert(adaptorSig.size == 97)
 
       // verify the adaptor signature "could be" repaired
-      assert(verifySchnorrAdaptorSignature(adaptorSig, msg, priv.publicKey))
+      assert(verifySchnorrAdaptorSignature(adaptorSig, msg, priv.publicKey.xonly))
 
       // repair the signature using  our knowledge of the scalar tweak value
       val repairedSig = repairSchnorrAdaptorSignature(
         adaptorSig = adaptorSig,
         data = msg,
-        publicKey = priv.publicKey,
         scalarTweak = tweak
       )
       assert(verifySignatureSchnorr(repairedSig, msg, priv.publicKey.xonly))
+      
+      val t = extractScalar(adaptorSig,repairedSig)
+      assert(t == tweak)
     }
 
-    test("adaptor signature deniability") {
-      import Crypto._
-
-      val priv = PrivateKey(
-        ByteVector32.fromValidHex(
-          "67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530"
+    test("a bunch of random adaptor sigs") {
+      import Crypto._, AdaptorSig._
+      val num_trials = 150
+      (0 until num_trials).foreach{ i =>
+        //println(s"index $i started")
+        val priv = PrivateKey(sha256(ByteVector(s"priv$i".getBytes)))
+        val msg = sha256(ByteVector(s"msg$i".getBytes))
+        val tweak = sha256(ByteVector(s"tweak$i".getBytes))
+        val tweakPoint = PrivateKey(tweak).publicKey
+        val adaptorSig = computeSchnorrAdaptorSignatureForPoint(
+          data = msg,
+          privateKey = priv,
+          tweakPoint = tweakPoint
         )
-      )
+        require(XOnlyPublicKey(ByteVector32(adaptorSig.take(32))) == PrivateKey(calculateBip340nonce(data = msg, privateKey = priv, auxrand32 = None)).publicKey.xonly, "R does not match")
+        require(PublicKey(adaptorSig.drop(64)).value == tweakPoint.value, "tweakPoint does not match")
+        assert(verifySchnorrAdaptorSignature(adaptorSig, msg, priv.publicKey.xonly))
+        val repairedSig = repairSchnorrAdaptorSignature(
+          adaptorSig = adaptorSig,
+          data = msg,
+          scalarTweak = tweak
+        )
+        assert(verifySignatureSchnorr(repairedSig, msg, priv.publicKey.xonly))
 
-      // normally the message to be signed is (the hash of) a bitcoin transaction
-      val data = sha256(ByteVector("abc".getBytes))
-
-      // create normal signature
-      val sig = signSchnorr(data, priv, auxrand32 = None)
-
-      // a scalar value which is the discrete logarithm of the "tweakPoint"
-      // Knowledge of this value is necessary in order to repair the adaptor
-      // signature into a valid BIP340 schnorr signature.
-      val tweak = sha256(ByteVector("efg".getBytes))
-
-      // turn the original signature into an adaptor signature
-      // notice how we did not need the signer's private key to do this,
-      // so this demonstrates a deniability property of adaptor signatures
-      // anybody can make them! (if you have a valid signature to start with first)
-      val adaptorSig = tweakSchnorrSignatureWithScalar(sig, tweak)
-
-      val repairedSig = repairSchnorrAdaptorSignature(
-        adaptorSig,
-        data,
-        priv.publicKey,
-        tweak
-      )
-      // repaired signature is valid
-      assert(verifySignatureSchnorr(repairedSig, data, priv.publicKey.xonly))
-
-      // repaired signature is the same as the original
-      assert(repairedSig == sig)
+        val extractedScalar = extractScalar(adaptorSig, repairedSig)
+        assert(extractedScalar == tweak)
+        //println(s"index $i succeeded!")
+        
+      }
     }
   }
 }


### PR DESCRIPTION
bunch of squashed commits, but here are the highlights:

* when repairing sig, need to negate scalarTweak when (R + T) is odd
* how to extract discrete log from adaptor sig
* a better randomized test of such adaptor sigs